### PR TITLE
Add sed script to trim whitespace around drive

### DIFF
--- a/snapraid-btrfs
+++ b/snapraid-btrfs
@@ -683,7 +683,7 @@ find_configs_try() {
     config="$1"
     found=
     if subvol="$("$my_snapper" -c "$config" get-config 2>/dev/null |
-        sed -e '/^SUBVOLUME /!d' -e 's/^SUBVOLUME[ ]*| //')"
+        sed -e '/^SUBVOLUME /!d' -e 's/^SUBVOLUME[ ]*| //' -e 's/\s*//g')"
     then
         while IFS=$' \t' read -r field1 field2 field3 ; do
             if [[ "$field1" =~ ^(data|disk)$ ]] &&


### PR DESCRIPTION
Hit an issue where when parsing the snapper output there was whitespace after the drive meaning it was never matched against. This can be seen using the following command. Adding the additional script to trim the drive resolves the issue and the configurations are now found.

```
$:~$ snapper -c mergerfsdisk4 get-config | sed -e '/^SUBVOLUME /!d' -e 's/^SUBVOLUME[ ]*| //' -e 's/\s+//g' | tr " " "*" | tr "\t" "&"
/mnt/disk4**********
```