### PR TITLE
Support snapper 0.11.0

### DIFF
--- a/snapraid-btrfs
+++ b/snapraid-btrfs
@@ -1,6 +1,6 @@
 #!/bin/bash -
 
-# Copyright (C) 2017-2023 Alex deBeus
+# Copyright (C) 2017-2025 Alex deBeus
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-readonly COPYRIGHT_YEARS='2017-2024'
+readonly COPYRIGHT_YEARS='2017-2025'
 readonly DEFAULT_CONFIG_FILE=/etc/snapraid.conf
 readonly DEFAULT_SNAPPER_CONFIG_DIR=/etc/snapper/configs
 readonly DEFAULT_TMPDIR=/tmp

--- a/snapraid-btrfs
+++ b/snapraid-btrfs
@@ -687,7 +687,7 @@ find_configs_try() {
     config="$1"
     found=
     if subvol="$("$my_snapper" -c "$config" get-config 2>/dev/null |
-        sed -e '/^SUBVOLUME /!d' -e 's/^SUBVOLUME[ ]*| //')"
+        sed -e '/^SUBVOLUME /!d' -e 's/^SUBVOLUME[ ]*| //' -e 's/^SUBVOLUME[ ]*│ //')"
     then
         while IFS=$' \t' read -r field1 field2 field3 ; do
             if [[ "$field1" =~ ^(data|disk)$ ]] &&

--- a/snapraid-btrfs
+++ b/snapraid-btrfs
@@ -687,7 +687,7 @@ find_configs_try() {
     config="$1"
     found=
     if subvol="$("$my_snapper" -c "$config" get-config 2>/dev/null |
-        sed -e '/^SUBVOLUME /!d' -e 's/^SUBVOLUME[ ]*| //' -e 's/^SUBVOLUME[ ]*│ //')"
+        sed -e '/^SUBVOLUME /!d' -e 's/^SUBVOLUME[ ]*[|│] //')"
     then
         while IFS=$' \t' read -r field1 field2 field3 ; do
             if [[ "$field1" =~ ^(data|disk)$ ]] &&

--- a/snapraid-btrfs
+++ b/snapraid-btrfs
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-readonly COPYRIGHT_YEARS='2017-2023'
+readonly COPYRIGHT_YEARS='2017-2024'
 readonly DEFAULT_CONFIG_FILE=/etc/snapraid.conf
 readonly DEFAULT_SNAPPER_CONFIG_DIR=/etc/snapper/configs
 readonly DEFAULT_TMPDIR=/tmp


### PR DESCRIPTION
Snapper 0.11.0 uses `│` (light vertical box drawing character) instead of `|` (pipe) so sed SUBVOLUME string matching fails, which in turn gives the error message "snapraid-btrfs: No snapper configs found for any data drives in /etc/snapraid.conf". This PR adds the vertical box drawing character to the sed command so either string is removed and snapper configs are matched appropriately. There is also a commit to update the copyright years.

using original code with snapper 0.11.0
```
$ snapper -c data1 get-config 2>/dev/null | sed -e '/^SUBVOLUME /!d' -e 's/^SUBVOLUME[ ]*| //'
SUBVOLUME              │ /mnt/data/1
```

using PR code with snapper 0.11.0
```
$ snapper -c data1 get-config 2>/dev/null | sed -e '/^SUBVOLUME /!d' -e 's/^SUBVOLUME[ ]*[|│] //'
/mnt/data/1
```