### PR TITLE
Fix "No snapper configs found for any data drives in..."

### DIFF
--- a/snapraid-btrfs
+++ b/snapraid-btrfs
@@ -690,6 +690,8 @@ find_configs_try() {
         sed -e '/^SUBVOLUME /!d' -e 's/^SUBVOLUME[ ]*| //')"
     then
         while IFS=$' \t' read -r field1 field2 field3 ; do
+            # Remove the snapshot subdir to match correctly
+            field3="${field3%/.snapshots/*/snapshot}"
             if [[ "$field1" =~ ^(data|disk)$ ]] &&
                    [[ "$field3" -ef "$subvol" ]]
             then


### PR DESCRIPTION
My configuration would replace the configuration file correctly, for example

```
data d1 /mnt/disk1/.snapshots/2/snapshot/
data d2 /mnt/disk2/.snapshots/2/snapshot/
data d3 /mnt/disk3/.snapshots/2/snapshot/
data d4 /mnt/disk4/.snapshots/2/snapshot/
data d5 /mnt/disk5/.snapshots/2/snapshot/
data d6 /mnt/disk6/.snapshots/2/snapshot/
```

This is expected behavior, however snapraid-btrfs will then attempt to match **/mnt/disk1/.snapshots/2/snapshot/** to **/mnt/disk1** and fail to detect the disk.

The patch I have prepared removes the **/.snapshots/*/snapshot/** substring to correctly match the disk as expected.